### PR TITLE
[현다솜] feat: MessageInput 컴포넌트 추가, sendMessage, replyMessage 연결

### DIFF
--- a/src/Components/MessageInput/MessageTextArea.tsx
+++ b/src/Components/MessageInput/MessageTextArea.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface MessageInputProps {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+}
+
+const MessageTextArea: React.FC<MessageInputProps> = ({ value, onChange }) => {
+  return (
+    <textarea
+      name="message"
+      id="message"
+      placeholder="메세지를 입력해주세요 ✍🏻"
+      onChange={onChange}
+      value={value}
+    />
+  );
+};
+
+export default MessageTextArea;

--- a/src/Components/MessageInput/index.tsx
+++ b/src/Components/MessageInput/index.tsx
@@ -12,6 +12,7 @@ const MessageInput = () => {
   // userId 받아오는 로직 추가
 
   // reply 하는 경우 messageId 받아오는 로직 추가
+  // messageId 받아오고 사용자이름, 메세지 내용 받아오기
 
   const onChangeInput = (e: React.ChangeEvent<HTMLTextAreaElement>): void => {
     setMessage(e.target.value);
@@ -35,6 +36,10 @@ const MessageInput = () => {
     setIsReply(true);
   };
 
+  const cancelReply = (): void => {
+    setIsReply(false);
+  };
+
   return (
     <>
       <section style={{ height: 'calc(80vh - 260px)' }}>
@@ -42,8 +47,18 @@ const MessageInput = () => {
         <button onClick={onClickReply}>임시reply버튼</button>
       </section>
       <section className="message-input">
-        <div className="message-input__textarea">
-          <MessageTextArea value={message} onChange={onChangeInput} />
+        <div className="message-input__left-menu">
+          {isReply && (
+            <button
+              className="message-input__left-menu__cancel-btn"
+              onClick={cancelReply}
+            >
+              reply 취소
+            </button>
+          )}
+          <div className="message-input__left-menu__textarea">
+            <MessageTextArea value={message} onChange={onChangeInput} />
+          </div>
         </div>
         <button
           type="button"

--- a/src/Components/MessageInput/index.tsx
+++ b/src/Components/MessageInput/index.tsx
@@ -2,20 +2,31 @@ import React, { useState } from 'react';
 import 'Components/MessageInput/scss/MessageInput.scss';
 
 const MessageInput = () => {
-  const [message, setMessage] = useState('');
+  const [message, setMessage] = useState<string>('');
+  const [isReply, setIsReply] = useState<boolean>(false);
 
-  const onChangeInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+  const onChangeInput = (e: React.ChangeEvent<HTMLTextAreaElement>): void => {
     setMessage(e.target.value);
   };
 
-  const onClickSend = () => {
+  const onClickSend = (): void => {
     console.log(message);
     setMessage('');
   };
 
+  const onClickReply = (): void => {
+    if (!isReply) {
+      setMessage(`사용자 이름\n` + `메시지 내용\n` + `(회신)\n` + message);
+    }
+    setIsReply(true);
+  };
+
   return (
     <>
-      <section style={{ height: 'calc(80vh - 260px)' }}>임시컨테이너</section>
+      <section style={{ height: 'calc(80vh - 260px)' }}>
+        임시컨테이너
+        <button onClick={onClickReply}>임시reply버튼</button>
+      </section>
       <section className="message-input">
         <div className="message-input__textarea">
           <textarea

--- a/src/Components/MessageInput/index.tsx
+++ b/src/Components/MessageInput/index.tsx
@@ -1,18 +1,31 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import { replyMessage, sendMessage } from 'Store/Actions';
 import 'Components/MessageInput/scss/MessageInput.scss';
 
 const MessageInput = () => {
   const [message, setMessage] = useState<string>('');
   const [isReply, setIsReply] = useState<boolean>(false);
+  const dispatch = useDispatch();
+
+  // userId 받아오는 로직 추가
+
+  // reply 하는 경우 messageId 받아오는 로직 추가
 
   const onChangeInput = (e: React.ChangeEvent<HTMLTextAreaElement>): void => {
     setMessage(e.target.value);
   };
 
-  const onClickSend = (): void => {
+  const onClickSend = useCallback((): void => {
     console.log(message);
-    setMessage('');
-  };
+
+    if (message) {
+      if (isReply) dispatch(replyMessage(4, message, 1));
+      else dispatch(sendMessage(4, message));
+      setMessage('');
+      setIsReply(false);
+    }
+  }, [dispatch, message, isReply]);
 
   const onClickReply = (): void => {
     if (!isReply) {
@@ -41,6 +54,7 @@ const MessageInput = () => {
           type="button"
           className="message-input__send-btn"
           onClick={onClickSend}
+          disabled={!message}
         >
           보내기
         </button>

--- a/src/Components/MessageInput/index.tsx
+++ b/src/Components/MessageInput/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { replyMessage, sendMessage } from 'Store/Actions';
+import MessageTextArea from 'Components/MessageInput/MessageTextArea';
 import 'Components/MessageInput/scss/MessageInput.scss';
 
 const MessageInput = () => {
@@ -42,13 +43,7 @@ const MessageInput = () => {
       </section>
       <section className="message-input">
         <div className="message-input__textarea">
-          <textarea
-            name="message"
-            id="message"
-            placeholder="메세지를 입력해주세요 ✍🏻"
-            onChange={onChangeInput}
-            value={message}
-          ></textarea>
+          <MessageTextArea value={message} onChange={onChangeInput} />
         </div>
         <button
           type="button"

--- a/src/Components/MessageInput/index.tsx
+++ b/src/Components/MessageInput/index.tsx
@@ -1,11 +1,40 @@
-import React from 'react';
+import React, { useState } from 'react';
 import 'Components/MessageInput/scss/MessageInput.scss';
 
 const MessageInput = () => {
+  const [message, setMessage] = useState('');
+
+  const onChangeInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setMessage(e.target.value);
+  };
+
+  const onClickSend = () => {
+    console.log(message);
+    setMessage('');
+  };
+
   return (
-    <section>
-      <h1>인풋</h1>
-    </section>
+    <>
+      <section style={{ height: 'calc(80vh - 260px)' }}>임시컨테이너</section>
+      <section className="message-input">
+        <div className="message-input__textarea">
+          <textarea
+            name="message"
+            id="message"
+            placeholder="메세지를 입력해주세요 ✍🏻"
+            onChange={onChangeInput}
+            value={message}
+          ></textarea>
+        </div>
+        <button
+          type="button"
+          className="message-input__send-btn"
+          onClick={onClickSend}
+        >
+          보내기
+        </button>
+      </section>
+    </>
   );
 };
 

--- a/src/Components/MessageInput/scss/MessageInput.scss
+++ b/src/Components/MessageInput/scss/MessageInput.scss
@@ -10,25 +10,36 @@
   padding: 25px 28px;
   box-sizing: border-box;
 
-  &__textarea {
-    background-color: white;
+  &__left-menu {
+    display: flex;
+    flex-direction: row;
     width: calc(100% - 108px);
     height: 88px;
     margin-right: 20px;
-    border: 1px solid $gray;
-    border-radius: 13px;
-    padding: 10px;
-    box-sizing: border-box;
 
-    & textarea {
-      display: inline-block;
+    &__cancel-btn {
+      margin-right: 10px;
+    }
+
+    &__textarea {
+      background-color: white;
       width: 100%;
-      height: 100%;
-      border: none;
-      resize: none;
+      // height: 100%;
+      border: 1px solid $gray;
+      border-radius: 13px;
+      padding: 10px;
+      box-sizing: border-box;
 
-      &:focus {
-        outline: none;
+      & textarea {
+        display: inline-block;
+        width: 100%;
+        height: 100%;
+        border: none;
+        resize: none;
+
+        &:focus {
+          outline: none;
+        }
       }
     }
   }

--- a/src/Components/MessageInput/scss/MessageInput.scss
+++ b/src/Components/MessageInput/scss/MessageInput.scss
@@ -1,0 +1,36 @@
+@import '../../../Utils/Styles/_variables';
+
+.message-input {
+  display: flex;
+  align-items: center;
+  width: inherit;
+  height: 140px;
+  background-color: $background;
+  border-radius: 0 0 20px 20px;
+  padding: 25px 28px;
+  box-sizing: border-box;
+
+  &__textarea {
+    background-color: white;
+    width: calc(100% - 108px);
+    height: 88px;
+    margin-right: 20px;
+    border: 1px solid $gray;
+    border-radius: 13px;
+    padding: 10px;
+    box-sizing: border-box;
+
+    & textarea {
+      display: inline-block;
+      width: 100%;
+      height: 100%;
+      border: none;
+      resize: none;
+    }
+  }
+
+  &__send-btn {
+    width: 88px;
+    height: 88px;
+  }
+}

--- a/src/Components/MessageInput/scss/MessageInput.scss
+++ b/src/Components/MessageInput/scss/MessageInput.scss
@@ -26,6 +26,10 @@
       height: 100%;
       border: none;
       resize: none;
+
+      &:focus {
+        outline: none;
+      }
     }
   }
 


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- MessageInput 컴포넌트 기능 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

- MessageInput 컴포넌트 생성
- Figma 디자인에 맞게 스타일링
- message 내용이 없을 때는 버튼 비활성화
- 임시 reply 버튼을 추가하여 reply 버튼을 누르면 input에 reply 구문 추가되도록 설정
- reply 버튼은 한번만 동작
- reply 취소버튼 생성
- reply 취소버튼 클릭시 isReply 가 false 로 설정되고 입력된 내용은 그대로 두었음
- Redux sendMessage, replyMessage 에 연결
- 입력한 값 콘솔창에서 보이도록 출력

<br />

## :: 기타 질문 및 특이 사항

1. reply 버튼을 취소할때 input에 입력된 reply 정보를 어떻게 관리해야할지 고민입니다
  reply 정보값이 일부 지워진 경우 값을 찾아올 수 없을 것 같습니다.
2. reply 버튼을 누른상태에서 다른 reply 버튼을 눌렀을 경우 
  messageId 값을 비교하면 체크할 수 있을 것 같은데 input 에 입력된 reply 정보를 대체할 수 없을 것 같습니다.
  정보를 대체하지 않는다면 reply 정보가 이중으로 삽입되어 더 혼란스러워질 것 같습니다.

- 위 두가지의 경우에서 1번은 지우지 않고 내부의 isReply 를 false 로 두고 내부의 reply 정보만 지우는 것으로 두고, 2번은 reply 취소 버튼을 눌러야 다른 reply 를 누를수 있도록 하는게 나을까요?