### PR TITLE
[현다솜, 정인권] feat: reply 관련 상태 관리, 함수 추가

### DIFF
--- a/src/Components/MessageInput/index.tsx
+++ b/src/Components/MessageInput/index.tsx
@@ -1,10 +1,18 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { replyMessage, sendMessage } from 'Store/Actions';
 import MessageTextArea from 'Components/MessageInput/MessageTextArea';
 import 'Components/MessageInput/scss/MessageInput.scss';
 
-const MessageInput = () => {
+interface MessageInputProps {
+  replyData: {
+    id: number;
+    userName: string;
+    message: string;
+  };
+}
+
+const MessageInput: React.FC<MessageInputProps> = ({ replyData }) => {
   const [message, setMessage] = useState<string>('');
   const [isReply, setIsReply] = useState<boolean>(false);
   const dispatch = useDispatch();
@@ -14,6 +22,12 @@ const MessageInput = () => {
   // reply 하는 경우 messageId 받아오는 로직 추가
   // messageId 받아오고 사용자이름, 메세지 내용 받아오기
 
+  useEffect(() => {
+    if (replyData.id !== 0) {
+      onClickReply();
+    }
+  }, [replyData]);
+
   const onChangeInput = (e: React.ChangeEvent<HTMLTextAreaElement>): void => {
     setMessage(e.target.value);
   };
@@ -22,8 +36,8 @@ const MessageInput = () => {
     console.log(message);
 
     if (message) {
-      if (isReply) dispatch(replyMessage(4, message, 1));
-      else dispatch(sendMessage(4, message));
+      if (isReply) dispatch(replyMessage(3, message, replyData.id));
+      else dispatch(sendMessage(3, message));
       setMessage('');
       setIsReply(false);
     }
@@ -31,7 +45,13 @@ const MessageInput = () => {
 
   const onClickReply = (): void => {
     if (!isReply) {
-      setMessage(`사용자 이름\n` + `메시지 내용\n` + `(회신)\n` + message);
+      // setMessage(`사용자 이름\n` + `메시지 내용\n` + `(회신)\n` + message);
+      setMessage(
+        `${replyData.userName}\n` +
+          `${replyData.message}\n` +
+          `(회신)\n` +
+          message
+      );
     }
     setIsReply(true);
   };
@@ -42,12 +62,11 @@ const MessageInput = () => {
 
   return (
     <>
-      <section>
-        임시컨테이너
-        <button onClick={onClickReply}>임시reply버튼</button>
-      </section>
       <section className="message-input">
         <div className="message-input__left-menu">
+          <div className="message-input__left-menu__textarea">
+            <MessageTextArea value={message} onChange={onChangeInput} />
+          </div>
           {isReply && (
             <button
               className="message-input__left-menu__cancel-btn"
@@ -56,9 +75,6 @@ const MessageInput = () => {
               reply 취소
             </button>
           )}
-          <div className="message-input__left-menu__textarea">
-            <MessageTextArea value={message} onChange={onChangeInput} />
-          </div>
         </div>
         <button
           type="button"

--- a/src/Components/MessageInput/index.tsx
+++ b/src/Components/MessageInput/index.tsx
@@ -42,7 +42,7 @@ const MessageInput = () => {
 
   return (
     <>
-      <section style={{ height: 'calc(80vh - 260px)' }}>
+      <section>
         임시컨테이너
         <button onClick={onClickReply}>임시reply버튼</button>
       </section>

--- a/src/Components/MessageInput/scss/MessageInput.scss
+++ b/src/Components/MessageInput/scss/MessageInput.scss
@@ -9,7 +9,6 @@
   border-radius: 0 0 20px 20px;
   padding: 25px 28px;
   box-sizing: border-box;
-  border: 2px solid red;
 
   &__left-menu {
     display: flex;

--- a/src/Components/MessageInput/scss/MessageInput.scss
+++ b/src/Components/MessageInput/scss/MessageInput.scss
@@ -18,7 +18,7 @@
     margin-right: 20px;
 
     &__cancel-btn {
-      margin-right: 10px;
+      margin-left: 10px;
     }
 
     &__textarea {

--- a/src/Components/MessageList/Message.tsx
+++ b/src/Components/MessageList/Message.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { MessageInterface, UserInterface } from 'Utils/Interface';
+import { ReplyDataInterface } from 'Utils/Interface';
 import 'Components/MessageList/scss/Message.scss';
 import Delete from 'Assets/Delete.png';
 import Reply from 'Assets/Reply.png';
@@ -7,22 +8,29 @@ import Reply from 'Assets/Reply.png';
 interface MessageProps {
   host: UserInterface | null;
   message: MessageInterface;
+  setReplyData: (data: ReplyDataInterface) => void;
 }
 
-const Message: React.FC<MessageProps> = ({ message, host }) => {
+const Message: React.FC<MessageProps> = ({ message, host, setReplyData }) => {
   const { id, user, content, date, reply } = message;
   console.log(reply);
 
-  const isHost = user.userId === host?.userId ? true : false;
+  const isHost = user.userId && user.userId === host?.userId ? true : false;
 
   const handleDelete = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.preventDefault();
-    console.log(id);
   };
+
+  console.log(content);
 
   const handleReply = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.preventDefault();
-    console.log(id);
+    const data: ReplyDataInterface = {
+      id,
+      userName: user.userName,
+      message: content,
+    };
+    setReplyData(data);
   };
 
   return (

--- a/src/Components/MessageList/index.tsx
+++ b/src/Components/MessageList/index.tsx
@@ -3,8 +3,13 @@ import { useSelector } from 'react-redux';
 import Message from 'Components/MessageList/Message';
 import { DataInterface, MessageInterface } from 'Utils/Interface';
 import 'Components/MessageList/scss/MessageList.scss';
+import { ReplyDataInterface } from 'Utils/Interface';
 
-const MessageList: React.FC = () => {
+interface MessageListProps {
+  setReplyData: (data: ReplyDataInterface) => void;
+}
+
+const MessageList: React.FC<MessageListProps> = ({ setReplyData }) => {
   const allMessages = useSelector((state: DataInterface) => state.allMessages);
   allMessages.sort((a, b) => {
     return Date.parse(a.date) - Date.parse(b.date);
@@ -22,7 +27,12 @@ const MessageList: React.FC = () => {
   return (
     <section className="messageList">
       {allMessages.map((message: MessageInterface) => (
-        <Message key={message.id} message={message} host={user} />
+        <Message
+          key={message.id}
+          message={message}
+          host={user}
+          setReplyData={setReplyData}
+        />
       ))}
       <div ref={messagesEndRef}></div>
     </section>

--- a/src/Pages/MessengerContainer.tsx
+++ b/src/Pages/MessengerContainer.tsx
@@ -1,16 +1,29 @@
-import React from 'react';
+import React, { useState } from 'react';
 import MessengerHeader from 'Components/MessengerHeader';
 import MessageList from 'Components/MessageList';
 import MessageInput from 'Components/MessageInput';
 import MessengerLogin from 'Components/MessengerLogin';
 import 'Pages/scss/MessengerContainer.scss';
+import { ReplyDataInterface } from 'Utils/Interface';
 
 const MessengerContainer = () => {
+  const [replyData, setReplyData] = useState<ReplyDataInterface>({
+    id: 0,
+    userName: '',
+    message: '',
+  });
+  // { userId, userName, message }
+
+  // const handlerSetReplayData = (data: ReplyDataInterface) => {
+  //   console.log(123);
+  //   setReplyData(data);
+  // };
+
   return (
     <main className="messenger-container">
       <MessengerHeader />
-      <MessageList />
-      <MessageInput />
+      <MessageList setReplyData={setReplyData} />
+      <MessageInput replyData={replyData} />
     </main>
   );
 };

--- a/src/Pages/MessengerContainer.tsx
+++ b/src/Pages/MessengerContainer.tsx
@@ -12,12 +12,6 @@ const MessengerContainer = () => {
     userName: '',
     message: '',
   });
-  // { userId, userName, message }
-
-  // const handlerSetReplayData = (data: ReplyDataInterface) => {
-  //   console.log(123);
-  //   setReplyData(data);
-  // };
 
   return (
     <main className="messenger-container">

--- a/src/Pages/scss/MessengerContainer.scss
+++ b/src/Pages/scss/MessengerContainer.scss
@@ -3,7 +3,7 @@
 .messenger-container {
   background-color: white;
   width: 550px;
-  height: 80vh;
+  // height: 80vh;
   border-radius: 20px;
   box-shadow: 2px 2px 15px rgba(0, 0, 0, 0.1);
   @include responsive(mobile) {

--- a/src/Store/Reducers/index.ts
+++ b/src/Store/Reducers/index.ts
@@ -32,7 +32,9 @@ const reducer = createReducer<DataInterface, MessengerAction>(initialState, {
       ...state.allMessages,
       {
         ...payload,
-        ...state.allUsers.filter((user) => user.userId === payload.userId)[0],
+        user: state.allUsers.filter(
+          (user) => user.userId === payload.userId
+        )[0],
       },
     ],
   }),

--- a/src/Utils/Interface/index.ts
+++ b/src/Utils/Interface/index.ts
@@ -33,3 +33,9 @@ export interface DataInterface {
   allUsers: UserInterface[];
   allMessages: MessageInterface[];
 }
+
+export interface ReplyDataInterface {
+  id: number;
+  userName: string;
+  message: string;
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- reply데이터가 MessageList 와 MessageInput 두 컴포넌트 간에 연결이 되어야 했어서 같이 reply 상태 관리 기능 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

- MessengerContainer 에 replyData 상태 추가
- MessageInput 에 replyData 를 받아와 reply 에 연결
- MessageList 에서 reply 버튼을 클릭시 replyData 를 업데이트되도록 함
- 메세지 전송시 ID 를 임시로 3번으로 설정
- message reducer 에서 user 정보가 제대로 전달 안되었던 부분 수정

<br />

## :: 기타 질문 및 특이 사항

- 없습니다
